### PR TITLE
Prefer output images over previews in viewer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import { useSwipeNavigation } from './hooks/useSwipeNavigation';
 import { useTextareaFocus } from './hooks/useTextareaFocus';
 import { useBookmarksStore } from './hooks/useBookmarks';
 import * as api from './api/client';
-import { buildViewerImages, type ViewerImage } from './utils/viewerImages';
+import { buildOutputPreferredViewerImages, type ViewerImage } from './utils/viewerImages';
 import { OutputsPanel } from './components/OutputsPanel';
 import { useOutputsStore } from './hooks/useOutputs';
 
@@ -134,7 +134,7 @@ function App() {
 
   // Open viewer in follow queue mode (from bottom bar button)
   const openFollowQueueViewer = () => {
-    const allImages = buildViewerImages(history, { alt: 'Generation' });
+    const allImages = buildOutputPreferredViewerImages(history, { alt: 'Generation' });
 
     // Disable swipe navigation before opening viewer
     setSwipeEnabled(false);

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -8,7 +8,7 @@ import { useQueueStore } from '@/hooks/useQueue';
 import { useHistoryStore } from '@/hooks/useHistory';
 import { useOverallProgress } from '@/hooks/useOverallProgress';
 import { useHistoryWorkflowByFileId } from '@/hooks/useHistoryWorkflowByFileId';
-import { buildViewerImages, type ViewerImage } from '@/utils/viewerImages';
+import { buildOutputPreferredViewerImages, type ViewerImage } from '@/utils/viewerImages';
 import { deleteFile, type FileItem } from '@/api/client';
 import { Dialog } from '@/components/modals/Dialog';
 import { UseImageModal } from '@/components/modals/UseImageModal';
@@ -86,7 +86,7 @@ export function ImageViewer({ onClose }: ImageViewerProps) {
     if (lastFollowPromptRef.current === latest.prompt_id) return;
     if (latest.outputs.images.length === 0) return;
 
-    const allImages = buildViewerImages(history, { alt: 'Generation' });
+    const allImages = buildOutputPreferredViewerImages(history, { alt: 'Generation' });
     if (allImages.length === 0) return;
 
     lastFollowPromptRef.current = latest.prompt_id;

--- a/src/components/QueuePanel.tsx
+++ b/src/components/QueuePanel.tsx
@@ -6,7 +6,7 @@ import { useWorkflowStore } from '@/hooks/useWorkflow';
 import { useNavigationStore } from '@/hooks/useNavigation';
 import { useOverallProgress } from '@/hooks/useOverallProgress';
 import type { Workflow } from '@/api/types';
-import { buildViewerImages } from '@/utils/viewerImages';
+import { buildOutputPreferredViewerImages } from '@/utils/viewerImages';
 import type { QueueItemData, UnifiedItem, ViewerImage } from './QueuePanel/types';
 import { QueueImageMenu } from './QueuePanel/QueueImageMenu';
 import { QueueToast } from './QueuePanel/QueueToast';
@@ -178,7 +178,7 @@ export function QueuePanel({ visible, onImageClick }: QueuePanelProps) {
 
   const viewerImages = useMemo(() => {
     const doneItems = unifiedList.filter((item) => item.status === 'done').map((item) => item.data);
-    return buildViewerImages(doneItems, { alt: 'Generation' });
+    return buildOutputPreferredViewerImages(doneItems, { alt: 'Generation' });
   }, [unifiedList]);
 
   const firstDoneItemId = useMemo(() => {

--- a/src/utils/__tests__/viewerImages.test.ts
+++ b/src/utils/__tests__/viewerImages.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { buildViewerImages, type HistoryImageItem } from '../viewerImages';
+import {
+  buildOutputPreferredViewerImages,
+  buildViewerImages,
+  type HistoryImageItem,
+} from '../viewerImages';
 
 describe('buildViewerImages', () => {
   const items: HistoryImageItem[] = [
@@ -29,6 +33,34 @@ describe('buildViewerImages', () => {
     expect(images.map((img) => img.filename)).toEqual([
       'saved-a.png',
       'saved-b.png',
+    ]);
+  });
+
+  it('prefers output images and skips previews when outputs exist', () => {
+    const images = buildOutputPreferredViewerImages(items, { alt: 'Generation' });
+    expect(images.map((img) => img.filename)).toEqual([
+      'saved-a.png',
+      'saved-b.png',
+    ]);
+  });
+
+  it('falls back to previews when there are no output images', () => {
+    const previewOnlyItems: HistoryImageItem[] = [
+      {
+        outputs: {
+          images: [
+            { filename: 'preview-a.png', subfolder: 'tmp', type: 'temp' },
+            { filename: 'preview-b.png', subfolder: 'tmp', type: 'temp' },
+          ],
+        },
+        prompt: {},
+      },
+    ];
+
+    const images = buildOutputPreferredViewerImages(previewOnlyItems, { alt: 'Generation' });
+    expect(images.map((img) => img.filename)).toEqual([
+      'preview-a.png',
+      'preview-b.png',
     ]);
   });
 });

--- a/src/utils/viewerImages.ts
+++ b/src/utils/viewerImages.ts
@@ -77,3 +77,13 @@ export function buildViewerImages(
 
   return images;
 }
+
+export function buildOutputPreferredViewerImages(
+  items: HistoryImageItem[],
+  options: Omit<BuildViewerImageOptions, 'onlyOutput'> = {}
+): ViewerImage[] {
+  const outputImages = buildViewerImages(items, { ...options, onlyOutput: true });
+  return outputImages.length > 0
+    ? outputImages
+    : buildViewerImages(items, options);
+}


### PR DESCRIPTION
## Summary
- When a history item has both saved outputs and temp previews, the viewer was mixing them together in the carousel
- Adds `buildOutputPreferredViewerImages` which returns output images when any exist, falling back to previews only when there are none
- Routes the follow-queue viewer (`App.tsx`), per-item viewer (`ImageViewer.tsx`), and queue panel (`QueuePanel.tsx`) through the new helper

## Test plan
- [x] `viewerImages` unit tests cover both the output-preferred and preview-fallback paths
- [ ] Manually verify the queue panel carousel shows only final outputs for completed runs that produced previews
- [ ] Manually verify the follow-queue viewer still shows previews when a run produced no outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)