### PR TITLE
Support ComfyUI V3 string-typed combo inputs

### DIFF
--- a/src/components/WorkflowPanel/NodeCard.tsx
+++ b/src/components/WorkflowPanel/NodeCard.tsx
@@ -3,6 +3,7 @@ import type { WorkflowInput, WorkflowNode } from '@/api/types';
 import { useWorkflowStore, getWidgetDefinitions, getInputWidgetDefinitions, getWidgetIndexForInput, findSeedWidgetIndex, findSeedControlWidgetIndex, resolveSubgraphPlaceholderWidgetDefs, resolveSubgraphPlaceholderInputWidgetDefs, resolveSubgraphProxyWidgetDefs, resolveSubgraphProxyInputWidgetDefs, resolveSubgraphBoundaryWidgetDefs, resolveSubgraphBoundaryInputWidgetDefs, isPlaceholderPromotedConnection } from '@/hooks/useWorkflow';
 import type { LinkedWidgetRoute, ProxyWidgetRoute } from '@/utils/widgetDefinitions';
 import { isSubgraphPlaceholder } from '@/utils/canonicalWorkflowOps';
+import { isComboType } from '@/utils/workflowInputs';
 import { isLoraManagerNodeType } from '@/utils/loraManager';
 import { useSeedStore } from '@/hooks/useSeed';
 import { useBookmarksStore } from '@/hooks/useBookmarks';
@@ -424,7 +425,7 @@ export const NodeCard = memo(function NodeCard({
     const inputDef = typeDef?.input?.required?.[input.name] || typeDef?.input?.optional?.[input.name];
     if (!inputDef) return false;
     const [typeOrOptions, options] = inputDef;
-    if (Array.isArray(typeOrOptions)) return true;
+    if (isComboType(typeOrOptions)) return true;
     const normalized = String(typeOrOptions).toUpperCase();
     const hasDefault = Object.prototype.hasOwnProperty.call(options ?? {}, 'default');
     return [

--- a/src/hooks/useWorkflow.ts
+++ b/src/hooks/useWorkflow.ts
@@ -49,6 +49,8 @@ import {
   isFileLikeToken,
   optionsAreFileLike,
   resolveComboOption,
+  isComboType,
+  getComboOptions,
 } from "@/utils/workflowInputs";
 import { buildWorkflowCacheKey } from "@/utils/workflowCacheKey";
 import { collectAllWorkflowGroups, collectAllWorkflowNodes } from "@/utils/workflowNodes";
@@ -1190,9 +1192,10 @@ function collectWorkflowLoadErrors(
         typeDef.input.required?.[name] || typeDef.input.optional?.[name];
       if (!inputDef) continue;
 
-      const [typeOrOptions] = inputDef;
-      if (!Array.isArray(typeOrOptions)) continue;
-      if (typeOrOptions.length === 0) continue;
+      const [typeOrOptions, inputOptions] = inputDef;
+      if (!isComboType(typeOrOptions)) continue;
+      const comboOpts = getComboOptions(typeOrOptions, inputOptions);
+      if (comboOpts.length === 0) continue;
 
       const inputEntry = node.inputs.find((input) => input.name === name);
       if (inputEntry?.link != null) continue;
@@ -1208,8 +1211,8 @@ function collectWorkflowLoadErrors(
       const rawValue = getWidgetValue(node, name, widgetIndex);
       if (rawValue === undefined || rawValue === null) continue;
 
-      const resolved = resolveComboOption(rawValue, typeOrOptions);
-      const normalized = normalizeWidgetValue(rawValue, typeOrOptions, {
+      const resolved = resolveComboOption(rawValue, comboOpts);
+      const normalized = normalizeWidgetValue(rawValue, comboOpts, {
         comboIndexToValue: true,
       });
       const normalizedString = String(normalized);
@@ -1217,7 +1220,7 @@ function collectWorkflowLoadErrors(
         normalizedString.split(/[\\/]/).pop() ?? normalizedString;
       const hasMatch =
         resolved !== undefined ||
-        typeOrOptions.some((opt) => {
+        comboOpts.some((opt) => {
           const optString = String(opt);
           return optString === normalizedString || optString === normalizedBase;
         });
@@ -1229,7 +1232,7 @@ function collectWorkflowLoadErrors(
       // enum-looking list — reach the server unchanged and can genuinely be
       // rejected, so those are what get flagged. The two rules have to agree:
       // anything kept but unflagged fails silently at run time instead.
-      if (!hasMatch && (optionsAreFileLike(typeOrOptions) || isFileLikeToken(normalizedString))) {
+      if (!hasMatch && (optionsAreFileLike(comboOpts) || isFileLikeToken(normalizedString))) {
         const nodeId = String(node.id);
         if (!errors[nodeId]) {
           errors[nodeId] = [];
@@ -1266,8 +1269,10 @@ function normalizeWorkflowComboValues(
     for (const name of orderedInputs) {
       const inputDef = typeDef.input.required?.[name] || typeDef.input.optional?.[name];
       if (!inputDef) continue;
-      const [typeOrOptions] = inputDef;
-      if (!Array.isArray(typeOrOptions) || typeOrOptions.length === 0) continue;
+      const [typeOrOptions, inputOptions] = inputDef;
+      if (!isComboType(typeOrOptions)) continue;
+      const comboOpts = getComboOptions(typeOrOptions, inputOptions);
+      if (comboOpts.length === 0) continue;
 
       const inputEntry = node.inputs.find((input) => input.name === name);
       if (inputEntry?.link != null) continue;
@@ -1279,7 +1284,7 @@ function normalizeWorkflowComboValues(
       const rawValue = getWidgetValue(node, name, widgetIndex);
       if (rawValue === undefined || rawValue === null) continue;
 
-      const resolved = resolveComboOption(rawValue, typeOrOptions);
+      const resolved = resolveComboOption(rawValue, comboOpts);
       if (resolved === undefined || resolved === rawValue) continue;
 
       if (!nextValues) {

--- a/src/utils/__tests__/fixtures/v3ComboFullNodes.json
+++ b/src/utils/__tests__/fixtures/v3ComboFullNodes.json
@@ -1,0 +1,962 @@
+{
+  "ResizeImageMaskNode": {
+    "name": "ResizeImageMaskNode",
+    "input": {
+      "required": {
+        "input": [
+          "COMFY_MATCHTYPE_V3",
+          {
+            "template": {
+              "template_id": "input_type",
+              "allowed_types": "IMAGE,MASK"
+            }
+          }
+        ],
+        "resize_type": [
+          "COMFY_DYNAMICCOMBO_V3",
+          {
+            "tooltip": "Select how to resize: by exact dimensions, scale factor, matching another image, etc.",
+            "options": [
+              {
+                "key": "scale dimensions",
+                "inputs": {
+                  "required": {
+                    "width": [
+                      "INT",
+                      {
+                        "tooltip": "Target width in pixels. Set to 0 to auto-calculate from height while preserving aspect ratio.",
+                        "default": 512,
+                        "min": 0,
+                        "max": 16384,
+                        "step": 1
+                      }
+                    ],
+                    "height": [
+                      "INT",
+                      {
+                        "tooltip": "Target height in pixels. Set to 0 to auto-calculate from width while preserving aspect ratio.",
+                        "default": 512,
+                        "min": 0,
+                        "max": 16384,
+                        "step": 1
+                      }
+                    ],
+                    "crop": [
+                      "COMBO",
+                      {
+                        "tooltip": "How to handle aspect ratio mismatch: 'disabled' stretches to fit, 'center' crops to maintain aspect ratio.",
+                        "default": "center",
+                        "multiselect": false,
+                        "options": [
+                          "disabled",
+                          "center"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "key": "scale by multiplier",
+                "inputs": {
+                  "required": {
+                    "multiplier": [
+                      "FLOAT",
+                      {
+                        "tooltip": "Scale factor (e.g., 2.0 doubles size, 0.5 halves size).",
+                        "default": 1.0,
+                        "min": 0.01,
+                        "max": 8.0,
+                        "step": 0.01
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "key": "scale longer dimension",
+                "inputs": {
+                  "required": {
+                    "longer_size": [
+                      "INT",
+                      {
+                        "tooltip": "The longer edge will be resized to this value. Aspect ratio is preserved.",
+                        "default": 512,
+                        "min": 0,
+                        "max": 16384,
+                        "step": 1
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "key": "scale shorter dimension",
+                "inputs": {
+                  "required": {
+                    "shorter_size": [
+                      "INT",
+                      {
+                        "tooltip": "The shorter edge will be resized to this value. Aspect ratio is preserved.",
+                        "default": 512,
+                        "min": 0,
+                        "max": 16384,
+                        "step": 1
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "key": "scale width",
+                "inputs": {
+                  "required": {
+                    "width": [
+                      "INT",
+                      {
+                        "tooltip": "Target width in pixels. Height auto-adjusts to preserve aspect ratio.",
+                        "default": 512,
+                        "min": 0,
+                        "max": 16384,
+                        "step": 1
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "key": "scale height",
+                "inputs": {
+                  "required": {
+                    "height": [
+                      "INT",
+                      {
+                        "tooltip": "Target height in pixels. Width auto-adjusts to preserve aspect ratio.",
+                        "default": 512,
+                        "min": 0,
+                        "max": 16384,
+                        "step": 1
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "key": "scale total pixels",
+                "inputs": {
+                  "required": {
+                    "megapixels": [
+                      "FLOAT",
+                      {
+                        "tooltip": "Target total megapixels (e.g., 1.0 \u2248 1024\u00d71024). Aspect ratio is preserved.",
+                        "default": 1.0,
+                        "min": 0.01,
+                        "max": 16.0,
+                        "step": 0.01
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "key": "match size",
+                "inputs": {
+                  "required": {
+                    "match": [
+                      "IMAGE,MASK",
+                      {
+                        "tooltip": "Resize input to match the dimensions of this reference image or mask."
+                      }
+                    ],
+                    "crop": [
+                      "COMBO",
+                      {
+                        "tooltip": "How to handle aspect ratio mismatch: 'disabled' stretches to fit, 'center' crops to maintain aspect ratio.",
+                        "default": "center",
+                        "multiselect": false,
+                        "options": [
+                          "disabled",
+                          "center"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "key": "scale to multiple",
+                "inputs": {
+                  "required": {
+                    "multiple": [
+                      "INT",
+                      {
+                        "tooltip": "Resize so width and height are divisible by this number. Useful for latent alignment (e.g., 8 or 64).",
+                        "default": 8,
+                        "min": 1,
+                        "max": 16384,
+                        "step": 1
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "scale_method": [
+          "COMBO",
+          {
+            "tooltip": "Interpolation algorithm. 'area' is best for downscaling, 'lanczos' for upscaling, 'nearest-exact' for pixel art.",
+            "default": "area",
+            "multiselect": false,
+            "options": [
+              "nearest-exact",
+              "bilinear",
+              "area",
+              "bicubic",
+              "lanczos"
+            ]
+          }
+        ]
+      }
+    },
+    "input_order": {
+      "required": [
+        "input",
+        "resize_type",
+        "scale_method"
+      ]
+    },
+    "output": [
+      "COMFY_MATCHTYPE_V3"
+    ],
+    "output_name": [
+      "resized"
+    ],
+    "display_name": "Resize Image/Mask",
+    "description": "",
+    "python_module": "comfy_extras.nodes_post_processing",
+    "category": "image/transform"
+  },
+  "ColorTransfer": {
+    "name": "ColorTransfer",
+    "input": {
+      "required": {
+        "image_target": [
+          "IMAGE",
+          {
+            "tooltip": "Image(s) to apply the color transform to."
+          }
+        ],
+        "image_ref": [
+          "IMAGE",
+          {
+            "tooltip": "Reference image(s) to match colors to."
+          }
+        ],
+        "method": [
+          "COMBO",
+          {
+            "multiselect": false,
+            "options": [
+              "reinhard_lab",
+              "mkl_lab",
+              "histogram"
+            ]
+          }
+        ],
+        "source_stats": [
+          "COMFY_DYNAMICCOMBO_V3",
+          {
+            "tooltip": "per_frame: each frame matched to image_ref individually. uniform: pool stats across all source frames as baseline, match to image_ref. target_frame: use one chosen frame as the baseline for the transform to image_ref, applied uniformly to all frames (preserves relative differences)",
+            "options": [
+              {
+                "key": "per_frame",
+                "inputs": {
+                  "required": {}
+                }
+              },
+              {
+                "key": "uniform",
+                "inputs": {
+                  "required": {}
+                }
+              },
+              {
+                "key": "target_frame",
+                "inputs": {
+                  "required": {
+                    "target_index": [
+                      "INT",
+                      {
+                        "tooltip": "Frame index used as the source baseline for computing the transform to image_ref",
+                        "default": 0,
+                        "min": 0,
+                        "max": 10000
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "strength": [
+          "FLOAT",
+          {
+            "default": 1.0,
+            "min": 0.0,
+            "max": 10.0,
+            "step": 0.01
+          }
+        ]
+      }
+    },
+    "input_order": {
+      "required": [
+        "image_target",
+        "image_ref",
+        "method",
+        "source_stats",
+        "strength"
+      ]
+    },
+    "output": [
+      "IMAGE"
+    ],
+    "output_name": [
+      "image"
+    ],
+    "display_name": "Transfer Color",
+    "description": "",
+    "python_module": "comfy_extras.nodes_post_processing",
+    "category": "image/filters"
+  },
+  "BasicScheduler": {
+    "name": "BasicScheduler",
+    "input": {
+      "required": {
+        "model": [
+          "MODEL",
+          {}
+        ],
+        "scheduler": [
+          "COMBO",
+          {
+            "multiselect": false,
+            "options": [
+              "simple",
+              "sgm_uniform",
+              "karras",
+              "exponential",
+              "ddim_uniform",
+              "beta",
+              "normal",
+              "linear_quadratic",
+              "kl_optimal",
+              "bong_tangent",
+              "beta57"
+            ]
+          }
+        ],
+        "steps": [
+          "INT",
+          {
+            "default": 20,
+            "min": 1,
+            "max": 10000
+          }
+        ],
+        "denoise": [
+          "FLOAT",
+          {
+            "default": 1.0,
+            "min": 0.0,
+            "max": 1.0,
+            "step": 0.01
+          }
+        ]
+      }
+    },
+    "input_order": {
+      "required": [
+        "model",
+        "scheduler",
+        "steps",
+        "denoise"
+      ]
+    },
+    "output": [
+      "SIGMAS"
+    ],
+    "output_name": [
+      "SIGMAS"
+    ],
+    "display_name": "BasicScheduler",
+    "description": "",
+    "python_module": "comfy_extras.nodes_custom_sampler",
+    "category": "model/sampling/schedulers"
+  },
+  "SaveImageAdvanced": {
+    "name": "SaveImageAdvanced",
+    "input": {
+      "required": {
+        "images": [
+          "IMAGE",
+          {
+            "tooltip": "The images to save."
+          }
+        ],
+        "filename_prefix": [
+          "STRING",
+          {
+            "tooltip": "The prefix for the file to save. May include formatting tokens such as %date:yyyy-MM-dd% or %Empty Latent Image.width%.",
+            "default": "ComfyUI",
+            "multiline": false
+          }
+        ],
+        "format": [
+          "COMFY_DYNAMICCOMBO_V3",
+          {
+            "tooltip": "The file format in which to save the image.",
+            "options": [
+              {
+                "key": "png",
+                "inputs": {
+                  "required": {
+                    "bit_depth": [
+                      "COMBO",
+                      {
+                        "advanced": true,
+                        "default": "8-bit",
+                        "multiselect": false,
+                        "options": [
+                          "8-bit",
+                          "16-bit"
+                        ]
+                      }
+                    ],
+                    "input_color_space": [
+                      "COMBO",
+                      {
+                        "advanced": true,
+                        "default": "sRGB",
+                        "multiselect": false,
+                        "options": [
+                          "sRGB"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "key": "exr",
+                "inputs": {
+                  "required": {
+                    "bit_depth": [
+                      "COMBO",
+                      {
+                        "advanced": true,
+                        "default": "32-bit float",
+                        "multiselect": false,
+                        "options": [
+                          "32-bit float"
+                        ]
+                      }
+                    ],
+                    "input_color_space": [
+                      "COMBO",
+                      {
+                        "tooltip": "Colorspace of the input tensor. The EXR is always written as scene-linear in the matching gamut.\nsRGB \u2014 input is sRGB-encoded Rec.709; the inverse sRGB EOTF is applied.\nHDR \u2014 input is HLG-encoded Rec.2020 (BT.2100); the inverse HLG OETF is applied to get scene-linear light.\nlinear \u2014 input is already scene-linear (Rec.709 primaries); written through unchanged. Use this for renderer/compositor output.",
+                        "advanced": true,
+                        "default": "sRGB",
+                        "multiselect": false,
+                        "options": [
+                          "sRGB",
+                          "HDR",
+                          "linear"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "hidden": {
+        "prompt": [
+          "PROMPT"
+        ],
+        "extra_pnginfo": [
+          "EXTRA_PNGINFO"
+        ]
+      }
+    },
+    "input_order": {
+      "required": [
+        "images",
+        "filename_prefix",
+        "format"
+      ],
+      "hidden": [
+        "prompt",
+        "extra_pnginfo"
+      ]
+    },
+    "output": [
+      "IMAGE"
+    ],
+    "output_name": [
+      "images"
+    ],
+    "display_name": "Save Image (Advanced)",
+    "description": "",
+    "python_module": "comfy_extras.nodes_images",
+    "category": "image"
+  },
+  "SaveVideo": {
+    "name": "SaveVideo",
+    "input": {
+      "required": {
+        "video": [
+          "VIDEO",
+          {
+            "tooltip": "The video to save."
+          }
+        ],
+        "filename_prefix": [
+          "STRING",
+          {
+            "tooltip": "The prefix for the file to save. This may include formatting information such as %date:yyyy-MM-dd% or %Empty Latent Image.width% to include values from nodes.",
+            "default": "video/ComfyUI",
+            "multiline": false
+          }
+        ],
+        "format": [
+          "COMBO",
+          {
+            "tooltip": "The format to save the video as.",
+            "default": "auto",
+            "multiselect": false,
+            "options": [
+              "auto",
+              "mp4"
+            ]
+          }
+        ],
+        "codec": [
+          "COMFY_DYNAMICCOMBO_V3",
+          {
+            "tooltip": "The codec to use for the video.",
+            "options": [
+              {
+                "key": "auto",
+                "inputs": {
+                  "required": {}
+                }
+              },
+              {
+                "key": "h264",
+                "inputs": {
+                  "required": {},
+                  "optional": {
+                    "encoding": [
+                      "COMFY_DYNAMICCOMBO_V3",
+                      {
+                        "display_name": "encoding mode",
+                        "tooltip": "Automatic preserves compatible H.264 streams. Re-encode applies a custom CRF.",
+                        "options": [
+                          {
+                            "key": "auto",
+                            "inputs": {
+                              "required": {}
+                            }
+                          },
+                          {
+                            "key": "re-encode",
+                            "inputs": {
+                              "required": {
+                                "crf": [
+                                  "FLOAT",
+                                  {
+                                    "tooltip": "Lower values produce higher quality and larger files.",
+                                    "default": 23.0,
+                                    "min": 0.0,
+                                    "max": 51.0,
+                                    "step": 1.0
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "hidden": {
+        "prompt": [
+          "PROMPT"
+        ],
+        "extra_pnginfo": [
+          "EXTRA_PNGINFO"
+        ]
+      }
+    },
+    "input_order": {
+      "required": [
+        "video",
+        "filename_prefix",
+        "format",
+        "codec"
+      ],
+      "hidden": [
+        "prompt",
+        "extra_pnginfo"
+      ]
+    },
+    "output": [
+      "VIDEO"
+    ],
+    "output_name": [
+      "video"
+    ],
+    "display_name": "Save Video",
+    "description": "",
+    "python_module": "comfy_extras.nodes_video",
+    "category": "video"
+  },
+  "SeedVR2TemporalChunk": {
+    "name": "SeedVR2TemporalChunk",
+    "input": {
+      "required": {
+        "latent": [
+          "LATENT",
+          {
+            "tooltip": "The VAE-encoded SeedVR2 latent to split."
+          }
+        ],
+        "temporal_overlap": [
+          "INT",
+          {
+            "tooltip": "Latent frames shared between adjacent chunks and crossfaded at merge; 0 = no overlap.",
+            "default": 0,
+            "min": 0,
+            "max": 16384
+          }
+        ],
+        "chunking_mode": [
+          "COMFY_DYNAMICCOMBO_V3",
+          {
+            "tooltip": "manual = use frames_per_chunk exactly; auto = predict the largest chunk that fits free VRAM.",
+            "options": [
+              {
+                "key": "auto",
+                "inputs": {
+                  "required": {}
+                }
+              },
+              {
+                "key": "manual",
+                "inputs": {
+                  "required": {
+                    "frames_per_chunk": [
+                      "INT",
+                      {
+                        "tooltip": "Pixel frames per temporal chunk (4n+1: 1, 5, 9, 13, ...).",
+                        "default": 21,
+                        "min": 1,
+                        "max": 16384,
+                        "step": 4
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "input_order": {
+      "required": [
+        "latent",
+        "temporal_overlap",
+        "chunking_mode"
+      ]
+    },
+    "output": [
+      "LATENT",
+      "INT"
+    ],
+    "output_name": [
+      "latents",
+      "temporal_overlap"
+    ],
+    "display_name": "Split SeedVR2 Latent",
+    "description": "",
+    "python_module": "comfy_extras.nodes_seedvr",
+    "category": "model/latent/batch"
+  },
+  "easy humanSegmentation": {
+    "name": "easy humanSegmentation",
+    "input": {
+      "required": {
+        "image": [
+          "IMAGE"
+        ],
+        "method": [
+          [
+            "selfie_multiclass_256x256",
+            "human_parsing_lip",
+            "human_parts (deeplabv3p)",
+            "segformer_b3_clothes",
+            "segformer_b3_fashion",
+            "face_parsing"
+          ]
+        ],
+        "confidence": [
+          "FLOAT",
+          {
+            "default": 0.4,
+            "min": 0.05,
+            "max": 0.95,
+            "step": 0.01
+          }
+        ],
+        "crop_multi": [
+          "FLOAT",
+          {
+            "default": 0.0,
+            "min": 0.0,
+            "max": 10.0,
+            "step": 0.001
+          }
+        ],
+        "mask_components": [
+          "EASY_COMBO",
+          {
+            "options": [
+              {
+                "label": "Background",
+                "value": 0
+              }
+            ],
+            "multi_select": {
+              "placeholder": "select mask components",
+              "chip": true,
+              "max_selected_labels": 4
+            }
+          }
+        ]
+      },
+      "hidden": {
+        "prompt": "PROMPT",
+        "my_unique_id": "UNIQUE_ID"
+      }
+    },
+    "input_order": {
+      "required": [
+        "image",
+        "method",
+        "confidence",
+        "crop_multi",
+        "mask_components"
+      ],
+      "hidden": [
+        "prompt",
+        "my_unique_id"
+      ]
+    },
+    "output": [
+      "IMAGE",
+      "MASK",
+      "BBOX"
+    ],
+    "output_name": [
+      "image",
+      "mask",
+      "bbox"
+    ],
+    "display_name": "Human Segmentation",
+    "description": "",
+    "python_module": "custom_nodes.comfyui-easy-use",
+    "category": "EasyUse/Segmentation"
+  },
+  "DecodeAndSaveVideo": {
+    "name": "DecodeAndSaveVideo",
+    "input": {
+      "required": {
+        "video_latent": [
+          "LATENT",
+          {
+            "tooltip": "The latent representation of the video frames."
+          }
+        ],
+        "fps": [
+          "FLOAT",
+          {
+            "tooltip": "Frame rate for the output video.",
+            "default": 25.0,
+            "min": 0.0,
+            "max": 999.0,
+            "step": 0.01
+          }
+        ],
+        "filename_prefix": [
+          "STRING",
+          {
+            "tooltip": "The prefix for the file to save. This may include formatting information such as %date:yyyy-MM-dd% or %Empty Latent Image.width% to include values from nodes.",
+            "default": "video/ComfyUI",
+            "multiline": false
+          }
+        ],
+        "format": [
+          "COMBO",
+          {
+            "tooltip": "The format to save the video as.",
+            "default": "auto",
+            "multiselect": false,
+            "options": [
+              "auto",
+              "mp4"
+            ]
+          }
+        ],
+        "codec": [
+          "COMBO",
+          {
+            "tooltip": "The codec to use for the video.",
+            "default": "auto",
+            "multiselect": false,
+            "options": [
+              "auto",
+              "h264"
+            ]
+          }
+        ],
+        "video_vae": [
+          "VAE",
+          {
+            "tooltip": "The VAE model to use for encoding."
+          }
+        ],
+        "tiling": [
+          "COMFY_DYNAMICCOMBO_V3",
+          {
+            "options": [
+              {
+                "key": "disabled",
+                "inputs": {
+                  "required": {}
+                }
+              },
+              {
+                "key": "enabled",
+                "inputs": {
+                  "required": {
+                    "tile_size": [
+                      "INT",
+                      {
+                        "tooltip": "Size of the tiles to decode. Smaller tiles use less memory but take more time.",
+                        "default": 512,
+                        "min": 64,
+                        "max": 4096,
+                        "step": 32
+                      }
+                    ],
+                    "overlap": [
+                      "INT",
+                      {
+                        "tooltip": "Amount of overlap between tiles. Higher overlap can improve quality at the edges of tiles but uses more memory and takes more time.",
+                        "default": 64,
+                        "min": 0,
+                        "max": 4096,
+                        "step": 32
+                      }
+                    ],
+                    "temporal_size": [
+                      "INT",
+                      {
+                        "tooltip": "Only used for video VAEs: Amount of frames to decode at a time. Higher value than number of frames = disabled",
+                        "default": 4096,
+                        "min": 8,
+                        "max": 4096,
+                        "step": 4
+                      }
+                    ],
+                    "temporal_overlap": [
+                      "INT",
+                      {
+                        "tooltip": "Only used for video VAEs: Amount of frames to overlap. Higher overlap can improve quality at the edges of temporal tiles but uses more memory and takes more time.",
+                        "default": 16,
+                        "min": 4,
+                        "max": 4096,
+                        "step": 4
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "optional": {
+        "audio_latent": [
+          "LATENT",
+          {
+            "tooltip": "The latent representation of the audio frames."
+          }
+        ],
+        "audio_vae": [
+          "VAE",
+          {
+            "tooltip": "The VAE model to use for decoding audio."
+          }
+        ]
+      },
+      "hidden": {
+        "prompt": [
+          "PROMPT"
+        ],
+        "extra_pnginfo": [
+          "EXTRA_PNGINFO"
+        ]
+      }
+    },
+    "input_order": {
+      "required": [
+        "video_latent",
+        "fps",
+        "filename_prefix",
+        "format",
+        "codec",
+        "video_vae",
+        "tiling"
+      ],
+      "optional": [
+        "audio_latent",
+        "audio_vae"
+      ],
+      "hidden": [
+        "prompt",
+        "extra_pnginfo"
+      ]
+    },
+    "output": [],
+    "output_name": [],
+    "display_name": "Decode and Save Video",
+    "description": "",
+    "python_module": "custom_nodes.comfyui-kjnodes",
+    "category": "KJNodes/image"
+  }
+}

--- a/src/utils/__tests__/v3ComboFixtures.test.ts
+++ b/src/utils/__tests__/v3ComboFixtures.test.ts
@@ -69,24 +69,12 @@ function defaultForSub(type: string, opts?: Record<string, unknown>): unknown {
   return null;
 }
 
+const PRIMITIVE_WIDGET_TYPES = ['INT', 'FLOAT', 'BOOLEAN', 'STRING'];
+
+/** An input occupies a widget slot when it is a combo or a primitive; everything else is a socket. */
 function isSocketType(t: unknown): boolean {
-  const tStr = String(t).toUpperCase();
-  // Anything that is a graph socket (not a form widget) in object_info.
-  return (
-    tStr === 'COMFY_MATCHTYPE_V3' ||
-    tStr === 'IMAGE' ||
-    tStr === 'MASK' ||
-    tStr === 'VIDEO' ||
-    tStr === 'LATENT' ||
-    tStr === 'MODEL' ||
-    tStr === 'CLIP' ||
-    tStr === 'VAE' ||
-    tStr === 'CONDITIONING' ||
-    tStr === 'AUDIO' ||
-    tStr.includes('IMAGE') ||
-    tStr.includes('MASK') ||
-    tStr.includes('LATENT')
-  );
+  if (isComboType(t as string | unknown[])) return false;
+  return !PRIMITIVE_WIDGET_TYPES.includes(String(t).toUpperCase());
 }
 
 /** Build widgets_values for a DynamicCombo selection + trailing sibling widgets. */
@@ -141,7 +129,7 @@ function widgetsForDynamicCombo(
       continue;
     }
 
-    if (['INT', 'FLOAT', 'BOOLEAN', 'STRING'].includes(String(t).toUpperCase())) {
+    if (PRIMITIVE_WIDGET_TYPES.includes(String(t).toUpperCase())) {
       widgets.push(defaultForSub(String(t), opts));
     }
   }

--- a/src/utils/__tests__/v3ComboFixtures.test.ts
+++ b/src/utils/__tests__/v3ComboFixtures.test.ts
@@ -1,0 +1,292 @@
+/**
+ * V3 combo coverage against real object_info node definitions, so the
+ * DynamicCombo sub-input plumbing is exercised without a live server.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import type { NodeTypes, Workflow, WorkflowNode } from '@/api/types';
+import {
+  buildWorkflowPromptInputs,
+  getComboOptions,
+  getDynamicComboSubInputs,
+  isComboType,
+} from '../workflowInputs';
+import { getInputWidgetDefinitions, getWidgetDefinitions } from '../widgetDefinitions';
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+
+const fullNodes = JSON.parse(
+  readFileSync(join(fixturesDir, 'v3ComboFullNodes.json'), 'utf8')
+) as NodeTypes;
+
+function makeNode(id: number, type: string, overrides?: Partial<WorkflowNode>): WorkflowNode {
+  return {
+    id,
+    type,
+    pos: [0, 0],
+    size: [200, 100],
+    flags: {},
+    order: 0,
+    mode: 0,
+    inputs: [],
+    outputs: [],
+    properties: {},
+    widgets_values: [],
+    ...overrides,
+  };
+}
+
+function makeWorkflow(nodes: WorkflowNode[]): Workflow {
+  return {
+    id: 'v3-fixture',
+    revision: 0,
+    last_node_id: nodes.length,
+    last_link_id: 0,
+    nodes,
+    links: [],
+    groups: [],
+    config: {},
+    extra: {},
+    version: 0.4,
+  };
+}
+
+function defaultForSub(type: string, opts?: Record<string, unknown>): unknown {
+  if (opts && Object.prototype.hasOwnProperty.call(opts, 'default')) {
+    return opts.default;
+  }
+  const t = String(type).toUpperCase();
+  if (t === 'INT') return 0;
+  if (t === 'FLOAT') return 1;
+  if (t === 'BOOLEAN') return false;
+  if (t === 'STRING') return '';
+  if (t === 'COMBO' || t === 'EASY_COMBO') {
+    const options = getComboOptions(type, opts);
+    return options[0] ?? '';
+  }
+  return null;
+}
+
+function isSocketType(t: unknown): boolean {
+  const tStr = String(t).toUpperCase();
+  // Anything that is a graph socket (not a form widget) in object_info.
+  return (
+    tStr === 'COMFY_MATCHTYPE_V3' ||
+    tStr === 'IMAGE' ||
+    tStr === 'MASK' ||
+    tStr === 'VIDEO' ||
+    tStr === 'LATENT' ||
+    tStr === 'MODEL' ||
+    tStr === 'CLIP' ||
+    tStr === 'VAE' ||
+    tStr === 'CONDITIONING' ||
+    tStr === 'AUDIO' ||
+    tStr.includes('IMAGE') ||
+    tStr.includes('MASK') ||
+    tStr.includes('LATENT')
+  );
+}
+
+/** Build widgets_values for a DynamicCombo selection + trailing sibling widgets. */
+function widgetsForDynamicCombo(
+  nodeType: string,
+  comboInputName: string,
+  selectedKey: string
+): { widgets: unknown[]; skipped: boolean; reason?: string } {
+  const typeDef = fullNodes[nodeType];
+  if (!typeDef) return { widgets: [], skipped: true, reason: 'missing type' };
+
+  const inputDef =
+    typeDef.input.required?.[comboInputName] || typeDef.input.optional?.[comboInputName];
+  if (!inputDef) return { widgets: [], skipped: true, reason: 'missing combo input' };
+
+  const [typeOrOptions, inputOptions] = inputDef;
+  const subs = getDynamicComboSubInputs(typeOrOptions, inputOptions, selectedKey, comboInputName);
+
+  for (const sub of subs) {
+    if (isSocketType(sub.inputDef[0])) {
+      return {
+        widgets: [],
+        skipped: true,
+        reason: `socket sub-input ${sub.name}:${String(sub.inputDef[0])}`,
+      };
+    }
+  }
+
+  const widgets: unknown[] = [];
+  const orderRequired = typeDef.input_order?.required ?? Object.keys(typeDef.input.required ?? {});
+  const orderOptional = typeDef.input_order?.optional ?? Object.keys(typeDef.input.optional ?? {});
+
+  for (const name of [...orderRequired, ...orderOptional]) {
+    const def = typeDef.input.required?.[name] || typeDef.input.optional?.[name];
+    if (!def) continue;
+    const [t, opts] = def;
+
+    if (isSocketType(t)) continue;
+
+    if (name === comboInputName) {
+      widgets.push(selectedKey);
+      for (const sub of subs) {
+        const [subType, subOpts] = sub.inputDef;
+        widgets.push(defaultForSub(String(subType), subOpts));
+      }
+      continue;
+    }
+
+    if (isComboType(t)) {
+      const comboOpts = getComboOptions(t, opts);
+      widgets.push(opts?.default ?? comboOpts[0] ?? '');
+      continue;
+    }
+
+    if (['INT', 'FLOAT', 'BOOLEAN', 'STRING'].includes(String(t).toUpperCase())) {
+      widgets.push(defaultForSub(String(t), opts));
+    }
+  }
+
+  return { widgets, skipped: false };
+}
+
+function allWidgetNames(node: WorkflowNode): string[] {
+  const nonCombo = getWidgetDefinitions(fullNodes, node).map((d) => d.name);
+  const combo = getInputWidgetDefinitions(fullNodes, node).map((d) => d.name);
+  return [...nonCombo, ...combo];
+}
+
+describe('v3 combo full-node prompt + widget defs (mocked, no UI)', () => {
+  it('ResizeImageMaskNode: each non-socket mode builds widgets + prompt fields', () => {
+    const comboName = 'resize_type';
+    const inputDef = fullNodes.ResizeImageMaskNode.input.required![comboName];
+    const [typeOrOptions, inputOptions] = inputDef;
+    const keys = getComboOptions(typeOrOptions, inputOptions).map(String);
+
+    expect(keys).toContain('scale dimensions');
+    expect(keys).toContain('scale by multiplier');
+
+    let exercised = 0;
+    for (const key of keys) {
+      const built = widgetsForDynamicCombo('ResizeImageMaskNode', comboName, key);
+      if (built.skipped) continue;
+
+      const node = makeNode(1, 'ResizeImageMaskNode', {
+        inputs: [{ name: 'input', type: 'IMAGE', link: 1 }],
+        widgets_values: built.widgets,
+      });
+      const workflow = makeWorkflow([node]);
+      const names = allWidgetNames(node);
+
+      expect(names, key).toContain(comboName);
+      const comboDef = getInputWidgetDefinitions(fullNodes, node).find((d) => d.name === comboName);
+      expect(comboDef?.value, key).toBe(key);
+
+      const subs = getDynamicComboSubInputs(typeOrOptions, inputOptions, key, comboName);
+      for (const sub of subs) {
+        expect(names, `${key} missing widget ${sub.name}`).toContain(sub.name);
+      }
+
+      const prompt = buildWorkflowPromptInputs(
+        workflow,
+        fullNodes,
+        node,
+        'ResizeImageMaskNode',
+        new Set([1]),
+        null
+      );
+      expect(prompt[comboName], key).toBe(key);
+      for (const sub of subs) {
+        expect(prompt, `${key} prompt`).toHaveProperty(sub.qualifiedName);
+      }
+      exercised += 1;
+    }
+
+    expect(exercised).toBeGreaterThanOrEqual(7);
+  });
+
+  it('SaveVideo / SaveImageAdvanced / ColorTransfer: combo options parse and prompt includes selection', () => {
+    const cases: Array<{ node: string; combo: string }> = [
+      { node: 'SaveVideo', combo: 'codec' },
+      { node: 'SaveImageAdvanced', combo: 'format' },
+      { node: 'ColorTransfer', combo: 'source_stats' },
+      { node: 'SeedVR2TemporalChunk', combo: 'chunking_mode' },
+      { node: 'DecodeAndSaveVideo', combo: 'tiling' },
+    ];
+
+    for (const { node: nodeType, combo } of cases) {
+      const typeDef = fullNodes[nodeType];
+      expect(typeDef, nodeType).toBeTruthy();
+      const inputDef = typeDef.input.required?.[combo] || typeDef.input.optional?.[combo];
+      expect(inputDef, `${nodeType}.${combo}`).toBeTruthy();
+      const [typeOrOptions, inputOptions] = inputDef!;
+      const keys = getComboOptions(typeOrOptions, inputOptions).map(String);
+      expect(keys.length, nodeType).toBeGreaterThan(0);
+
+      const key = keys[0];
+      const built = widgetsForDynamicCombo(nodeType, combo, key);
+      if (built.skipped) {
+        expect(keys[0]).toBeTruthy();
+        continue;
+      }
+
+      const socketInputs = Object.entries({
+        ...(typeDef.input.required ?? {}),
+        ...(typeDef.input.optional ?? {}),
+      })
+        .filter(([, def]) => isSocketType(def[0]))
+        .map(([name, def], idx) => ({
+          name,
+          type: String(def[0]),
+          link: idx + 1,
+        }));
+
+      const node = makeNode(1, nodeType, {
+        inputs: socketInputs,
+        widgets_values: built.widgets,
+      });
+      const workflow = makeWorkflow([node]);
+      const prompt = buildWorkflowPromptInputs(
+        workflow,
+        fullNodes,
+        node,
+        nodeType,
+        new Set([1]),
+        null
+      );
+      expect(prompt[combo], nodeType).toBe(key);
+    }
+  });
+
+  it('easy humanSegmentation EASY_COMBO options flatten via getComboOptions', () => {
+    const typeDef = fullNodes['easy humanSegmentation'];
+    expect(typeDef).toBeTruthy();
+    const inputDef = typeDef.input.required!['mask_components'];
+    const [typeOrOptions, inputOptions] = inputDef;
+    expect(String(typeOrOptions).toUpperCase()).toBe('EASY_COMBO');
+    const options = getComboOptions(typeOrOptions, inputOptions);
+    expect(options.length).toBeGreaterThan(0);
+  });
+
+  it('BasicScheduler string COMBO still resolves like classic combo', () => {
+    const typeDef = fullNodes.BasicScheduler;
+    const inputDef = typeDef.input.required!['scheduler'];
+    const [typeOrOptions, inputOptions] = inputDef;
+    expect(isComboType(typeOrOptions)).toBe(true);
+    const options = getComboOptions(typeOrOptions, inputOptions);
+    expect(options.length).toBeGreaterThan(0);
+
+    const node = makeNode(1, 'BasicScheduler', {
+      inputs: [{ name: 'model', type: 'MODEL', link: 1 }],
+      widgets_values: [options[0], 20, 1],
+    });
+    const prompt = buildWorkflowPromptInputs(
+      makeWorkflow([node]),
+      fullNodes,
+      node,
+      'BasicScheduler',
+      new Set([1]),
+      null
+    );
+    expect(prompt.scheduler).toBe(options[0]);
+  });
+});

--- a/src/utils/__tests__/workflowInputs.test.ts
+++ b/src/utils/__tests__/workflowInputs.test.ts
@@ -4,6 +4,10 @@ import {
   getWidgetValue,
   getWorkflowWidgetIndexMap,
   isWidgetInputType,
+  isComboType,
+  isV3ComboType,
+  getComboOptions,
+  getDynamicComboSubInputs,
   normalizeWidgetValue,
   normalizeComboValue,
   optionsAreFileLike,
@@ -137,6 +141,155 @@ describe('isWidgetInputType', () => {
     expect(isWidgetInputType('MODEL')).toBe(false);
     expect(isWidgetInputType('LATENT')).toBe(false);
     expect(isWidgetInputType('CONDITIONING')).toBe(false);
+  });
+});
+
+describe('isV3ComboType', () => {
+  it('returns true for V3 combo type strings', () => {
+    expect(isV3ComboType('COMBO')).toBe(true);
+    expect(isV3ComboType('combo')).toBe(true);
+    expect(isV3ComboType('COMFY_DYNAMICCOMBO_V3')).toBe(true);
+    expect(isV3ComboType('EASY_COMBO')).toBe(true);
+  });
+
+  it('returns false for non-combo type strings', () => {
+    expect(isV3ComboType('INT')).toBe(false);
+    expect(isV3ComboType('STRING')).toBe(false);
+    expect(isV3ComboType('MODEL')).toBe(false);
+    expect(isV3ComboType('COMFY_MATCHTYPE_V3')).toBe(false);
+    expect(isV3ComboType('COMFY_AUTOGROW_V3')).toBe(false);
+  });
+
+  it('returns false for arrays', () => {
+    expect(isV3ComboType(['euler', 'ddim'])).toBe(false);
+  });
+});
+
+describe('isComboType', () => {
+  it('returns true for arrays', () => {
+    expect(isComboType(['euler', 'ddim'])).toBe(true);
+  });
+
+  it('returns true for V3 combo type strings', () => {
+    expect(isComboType('COMBO')).toBe(true);
+    expect(isComboType('COMFY_DYNAMICCOMBO_V3')).toBe(true);
+    expect(isComboType('EASY_COMBO')).toBe(true);
+  });
+
+  it('returns false for non-combo types', () => {
+    expect(isComboType('INT')).toBe(false);
+    expect(isComboType('MODEL')).toBe(false);
+    expect(isComboType('COMFY_MATCHTYPE_V3')).toBe(false);
+  });
+});
+
+describe('getComboOptions', () => {
+  it('returns array directly for legacy array-typed combos', () => {
+    expect(getComboOptions(['euler', 'ddim'])).toEqual(['euler', 'ddim']);
+  });
+
+  it('extracts options from COMBO type', () => {
+    const opts = { options: ['a', 'b', 'c'] };
+    expect(getComboOptions('COMBO', opts)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('extracts key from COMFY_DYNAMICCOMBO_V3 options', () => {
+    const opts = {
+      options: [
+        { key: 'scale dimensions', inputs: {} },
+        { key: 'scale by multiplier', inputs: {} },
+      ],
+    };
+    expect(getComboOptions('COMFY_DYNAMICCOMBO_V3', opts)).toEqual([
+      'scale dimensions',
+      'scale by multiplier',
+    ]);
+  });
+
+  it('extracts value from EASY_COMBO options', () => {
+    const opts = {
+      options: [
+        { label: 'Foo', value: 'foo' },
+        { label: 'Bar', value: 'bar' },
+      ],
+    };
+    expect(getComboOptions('EASY_COMBO', opts)).toEqual(['foo', 'bar']);
+  });
+
+  it('returns empty array when options is missing', () => {
+    expect(getComboOptions('COMBO', {})).toEqual([]);
+    expect(getComboOptions('COMBO', undefined)).toEqual([]);
+  });
+});
+
+describe('getDynamicComboSubInputs', () => {
+  it('returns sub-inputs for the selected DYNAMICCOMBO option', () => {
+    const opts = {
+      options: [
+        {
+          key: 'scale dimensions',
+          inputs: {
+            required: {
+              width: ['INT', { default: 512, min: 0, max: 16384 }],
+              height: ['INT', { default: 512, min: 0, max: 16384 }],
+            },
+            optional: {
+              crop: ['COMBO', { options: ['disabled', 'center'] }],
+            },
+          },
+        },
+        {
+          key: 'scale by multiplier',
+          inputs: {
+            required: {
+              multiplier: ['FLOAT', { default: 1.0 }],
+            },
+          },
+        },
+      ],
+    };
+    const subInputs = getDynamicComboSubInputs('COMFY_DYNAMICCOMBO_V3', opts, 'scale dimensions', 'resize_type');
+    expect(subInputs).toHaveLength(3);
+    expect(subInputs[0].name).toBe('width');
+    expect(subInputs[0].qualifiedName).toBe('resize_type.width');
+    expect(subInputs[0].inputDef[0]).toBe('INT');
+    expect(subInputs[1].name).toBe('height');
+    expect(subInputs[1].qualifiedName).toBe('resize_type.height');
+    expect(subInputs[2].name).toBe('crop');
+    expect(subInputs[2].qualifiedName).toBe('resize_type.crop');
+  });
+
+  it('returns sub-inputs for the other option', () => {
+    const opts = {
+      options: [
+        {
+          key: 'scale dimensions',
+          inputs: { required: { width: ['INT', {}] } },
+        },
+        {
+          key: 'scale by multiplier',
+          inputs: { required: { multiplier: ['FLOAT', { default: 1.0 }] } },
+        },
+      ],
+    };
+    const subInputs = getDynamicComboSubInputs('COMFY_DYNAMICCOMBO_V3', opts, 'scale by multiplier', 'resize_type');
+    expect(subInputs).toHaveLength(1);
+    expect(subInputs[0].name).toBe('multiplier');
+    expect(subInputs[0].qualifiedName).toBe('resize_type.multiplier');
+  });
+
+  it('returns empty array for non-DYNAMICCOMBO types', () => {
+    expect(getDynamicComboSubInputs('COMBO', { options: ['a', 'b'] }, 'a')).toEqual([]);
+    expect(getDynamicComboSubInputs(['a', 'b'], undefined, 'a')).toEqual([]);
+  });
+
+  it('returns empty array when selected value does not match any option', () => {
+    const opts = {
+      options: [
+        { key: 'option1', inputs: { required: { x: ['INT', {}] } } },
+      ],
+    };
+    expect(getDynamicComboSubInputs('COMFY_DYNAMICCOMBO_V3', opts, 'nonexistent')).toEqual([]);
   });
 });
 

--- a/src/utils/seedUtils.ts
+++ b/src/utils/seedUtils.ts
@@ -1,5 +1,5 @@
 import type { Workflow, WorkflowNode, NodeTypes } from '@/api/types';
-import { getNodeWidgetIndexMap, isWidgetInputType, skipImplicitSeedControlSlot } from '@/utils/workflowInputs';
+import { getNodeWidgetIndexMap, isWidgetInputType, isComboType, skipImplicitSeedControlSlot } from '@/utils/workflowInputs';
 
 // Seed mode type
 export type SeedMode = 'fixed' | 'randomize' | 'increment' | 'decrement';
@@ -125,7 +125,8 @@ export function getWidgetIndexForInput(
     const isConnected = inputEntry?.link != null;
     const isWidgetToggle = Boolean(inputEntry?.widget) && !isConnected;
     const hasSocket = Boolean(inputEntry);
-    const isWidgetType = isWidgetInputType(typeOrOptions) || isWidgetToggle || !hasSocket;
+    // V3 string-typed combos ("COMBO", etc.) are not covered by isWidgetInputType.
+    const isWidgetType = isWidgetInputType(typeOrOptions) || isWidgetToggle || !hasSocket || (!isConnected && isComboType(typeOrOptions));
     const isWidget = isWidgetType;
 
     if (isWidget) {
@@ -209,7 +210,8 @@ export function findSeedWidgetIndex(
     const isConnected = inputEntry?.link != null;
     const isWidgetToggle = Boolean(inputEntry?.widget) && !isConnected;
     const hasSocket = Boolean(inputEntry);
-    const isWidgetType = isWidgetInputType(typeOrOptions) || isWidgetToggle || !hasSocket;
+    // V3 string-typed combos ("COMBO", etc.) are not covered by isWidgetInputType.
+    const isWidgetType = isWidgetInputType(typeOrOptions) || isWidgetToggle || !hasSocket || (!isConnected && isComboType(typeOrOptions));
 
     if (isWidgetType) {
       const mappedIndex = widgetIndexMap?.[name];

--- a/src/utils/widgetDefinitions.ts
+++ b/src/utils/widgetDefinitions.ts
@@ -1,5 +1,5 @@
 import type { WorkflowInput, WorkflowLink, WorkflowNode, NodeTypes, NodeTypeDefinition, NodeInputEntry, Workflow, WorkflowSubgraphLink, WorkflowSubgraphDefinition } from '@/api/types';
-import { getNodePropertyWidgetIndexMap, getWidgetValue, isWidgetInputType, skipImplicitSeedControlSlot } from '@/utils/workflowInputs';
+import { getNodePropertyWidgetIndexMap, getWidgetValue, isWidgetInputType, isComboType, getComboOptions, getDynamicComboSubInputs, skipImplicitSeedControlSlot } from '@/utils/workflowInputs';
 import { findLoraListIndex, isLoraList, isLoraManagerNodeType, isPowerLoraLoaderNodeType } from '@/utils/loraManager';
 import { modelWidgetKind } from '@/utils/modelWidgetKind';
 import {
@@ -283,10 +283,11 @@ function collectWidgetDefinitions(
       const isWidgetToggle = Boolean(inputEntry?.widget) && !isConnected;
       const hasSocket = Boolean(inputEntry);
       const hasDefault = Object.prototype.hasOwnProperty.call(inputOptions ?? {}, 'default');
-      const isWidgetType = isWidgetInputType(typeOrOptions) || isWidgetToggle || !hasSocket || hasDefault;
-      const isCombo = Array.isArray(typeOrOptions) && !isAutocompleteTextInput;
+      // V3 string-typed combos ("COMBO", etc.) are not covered by isWidgetInputType.
+      const isWidgetType = isWidgetInputType(typeOrOptions) || isWidgetToggle || !hasSocket || hasDefault || (!isConnected && isComboType(typeOrOptions));
+      const isCombo = isComboType(typeOrOptions) && !isAutocompleteTextInput;
       const comboOptions: Record<string, unknown> = isCombo
-        ? { ...(inputOptions ?? {}), options: typeOrOptions }
+        ? { ...(inputOptions ?? {}), options: getComboOptions(typeOrOptions, inputOptions) }
         : { ...(inputOptions ?? {}) };
       // PrimitiveString holds free text (often popped out of a multiline widget
       // like CLIP text) — render it as a multiline textarea, not a one-line box.
@@ -323,6 +324,17 @@ function collectWidgetDefinitions(
           // which would be the value of the next real widget.
           if (skipImplicitSeedControlSlot(node, widgetIndex)) {
             widgetIndex += 1;
+          }
+        }
+        // COMFY_DYNAMICCOMBO_V3: the selected option exposes conditional
+        // sub-inputs (e.g. width/height/crop) that appear as additional
+        // widgets in widgets_values right after the combo value.
+        // Process them recursively so they show up as widget definitions.
+        if (String(typeOrOptions).toUpperCase() === 'COMFY_DYNAMICCOMBO_V3') {
+          const lastDef = definitions[definitions.length - 1];
+          const subInputs = getDynamicComboSubInputs(typeOrOptions, inputOptions, lastDef?.value, name);
+          for (const { name: subName, inputDef: subInputDef } of subInputs) {
+            processInput(subName, subInputDef);
           }
         }
       }

--- a/src/utils/workflowInputs.ts
+++ b/src/utils/workflowInputs.ts
@@ -235,6 +235,88 @@ export function isWidgetInputType(typeOrOptions: string | unknown[]): boolean {
     normalized.includes('AUTOCOMPLETE_TEXT_PROMPT');
 }
 
+// V3 combo type strings used by ComfyUI's newer API format.
+// - COMBO: options in inputDef[1].options (string array)
+// - COMFY_DYNAMICCOMBO_V3: options in inputDef[1].options (array of {key, inputs} objects)
+// - EASY_COMBO: options in inputDef[1].options (array of {label, value} objects)
+// COMFY_AUTOGROW_V3 and COMFY_MATCHTYPE_V3 are socket-only, NOT widget combos.
+const V3_COMBO_TYPES = new Set(['COMBO', 'COMFY_DYNAMICCOMBO_V3', 'EASY_COMBO']);
+
+export function isV3ComboType(typeOrOptions: string | unknown[]): boolean {
+  if (Array.isArray(typeOrOptions)) return false;
+  return V3_COMBO_TYPES.has(String(typeOrOptions).toUpperCase());
+}
+
+export function isComboType(typeOrOptions: string | unknown[]): boolean {
+  return Array.isArray(typeOrOptions) || isV3ComboType(typeOrOptions);
+}
+
+export function getComboOptions(
+  typeOrOptions: string | unknown[],
+  inputOptions?: Record<string, unknown>
+): unknown[] {
+  if (Array.isArray(typeOrOptions)) {
+    return typeOrOptions;
+  }
+  const typeName = String(typeOrOptions).toUpperCase();
+  const rawOptions = inputOptions?.options;
+  if (!Array.isArray(rawOptions)) return [];
+  if (typeName === 'EASY_COMBO') {
+    return rawOptions.map((opt: unknown) =>
+      typeof opt === 'object' && opt !== null && 'value' in opt
+        ? (opt as Record<string, unknown>).value
+        : opt
+    );
+  }
+  if (typeName === 'COMFY_DYNAMICCOMBO_V3') {
+    return rawOptions.map((opt: unknown) =>
+      typeof opt === 'object' && opt !== null && 'key' in opt
+        ? (opt as Record<string, unknown>).key
+        : opt
+    );
+  }
+  // COMBO or unknown string-typed combo: options are plain strings
+  return rawOptions;
+}
+
+export interface DynamicComboSubInput {
+  name: string;           // unprefixed name (for widget lookups)
+  qualifiedName: string;  // prefixed name (for API prompt submission)
+  inputDef: [string | unknown[], Record<string, unknown>?];
+}
+
+export function getDynamicComboSubInputs(
+  typeOrOptions: string | unknown[],
+  inputOptions: Record<string, unknown> | undefined,
+  selectedValue: unknown,
+  parentName?: string,
+): DynamicComboSubInput[] {
+  if (!isV3ComboType(typeOrOptions) || String(typeOrOptions).toUpperCase() !== 'COMFY_DYNAMICCOMBO_V3') {
+    return [];
+  }
+  const rawOptions = inputOptions?.options;
+  if (!Array.isArray(rawOptions)) return [];
+  const selectedKey = String(selectedValue);
+  const option = rawOptions.find(
+    (opt: unknown) =>
+      typeof opt === 'object' && opt !== null && 'key' in opt &&
+      String((opt as Record<string, unknown>).key) === selectedKey
+  ) as Record<string, unknown> | undefined;
+  if (!option) return [];
+  const subInputs = option.inputs as Record<string, Record<string, [string | unknown[], Record<string, unknown>?]>> | undefined;
+  if (!subInputs) return [];
+  const prefix = parentName ? `${parentName}.` : '';
+  const result: DynamicComboSubInput[] = [];
+  for (const section of ['required', 'optional']) {
+    const sectionInputs = subInputs[section];
+    if (!sectionInputs) continue;
+    for (const [name, inputDef] of Object.entries(sectionInputs)) {
+      result.push({ name, qualifiedName: `${prefix}${name}`, inputDef });
+    }
+  }
+  return result;
+}
+
 export function normalizeWidgetValue(
   value: unknown,
   typeOrOptions: string | unknown[],
@@ -538,14 +620,15 @@ export function buildWorkflowPromptInputs(
       const inputDef = typeDef.input.required?.[name] || typeDef.input.optional?.[name];
       if (!inputDef) continue;
 
-      const [typeOrOptions] = inputDef;
+      const [typeOrOptions, inputOptions] = inputDef;
       const inputEntry = node.inputs.find((i) => i.name === name);
       const isConnected = inputEntry?.link != null;
       const isWidgetToggle = Boolean(inputEntry?.widget) && !isConnected;
       const hasSocket = Boolean(inputEntry);
       const defaultValue = inputDef[1]?.default;
       const hasDefault = Object.prototype.hasOwnProperty.call(inputDef[1] ?? {}, 'default');
-      const isWidgetType = isWidgetInputType(typeOrOptions) || isWidgetToggle || !hasSocket;
+      // V3 string-typed combos ("COMBO", etc.) are not covered by isWidgetInputType.
+      const isWidgetType = isWidgetInputType(typeOrOptions) || isWidgetToggle || !hasSocket || (!isConnected && isComboType(typeOrOptions));
       const isWidget = isWidgetType;
 
       if (isWidget) {
@@ -567,11 +650,12 @@ export function buildWorkflowPromptInputs(
         } else if (indexToUse !== undefined && !isConnected && !(name in inputs)) {
           const rawValue = getWidgetValue(node, name, indexToUse);
           if (rawValue !== undefined) {
-            if (Array.isArray(typeOrOptions)) {
+            if (isComboType(typeOrOptions)) {
+              const comboOpts = getComboOptions(typeOrOptions, inputOptions);
               inputs[name] = finalizeInputValue(
                 workflow,
                 name,
-                normalizeComboValue(rawValue, typeOrOptions)
+                normalizeComboValue(rawValue, comboOpts)
               );
             } else {
               inputs[name] = finalizeInputValue(
@@ -596,6 +680,44 @@ export function buildWorkflowPromptInputs(
               widgetCursor = Math.max(widgetCursor, indexToUse + 2);
             } else {
               widgetCursor = Math.max(widgetCursor, widgetCursor + 1);
+            }
+          }
+        }
+
+        // COMFY_DYNAMICCOMBO_V3: process conditional sub-inputs (width/height/crop, etc.)
+        // that appear as additional widgets in widgets_values after the combo value.
+        if (String(typeOrOptions).toUpperCase() === 'COMFY_DYNAMICCOMBO_V3') {
+          const comboValue = inputs[name];
+          const subInputs = getDynamicComboSubInputs(typeOrOptions, inputOptions, comboValue, name);
+          for (const { name: subName, qualifiedName: subQualifiedName, inputDef: subInputDef } of subInputs) {
+            if (subQualifiedName in inputs) continue;
+            const [subType, subOpts] = subInputDef;
+            const subHasDefault = Object.prototype.hasOwnProperty.call(subOpts ?? {}, 'default');
+            const subEntry = node.inputs.find((i) => i.name === subName);
+            const subIsConnected = subEntry?.link != null;
+            if (subIsConnected) continue;
+            const subIndex = widgetIndexMap?.[subName] ?? widgetCursor;
+            const subRawValue = getWidgetValue(node, subName, subIndex);
+            if (subRawValue !== undefined) {
+              if (isComboType(subType)) {
+                const subComboOpts = getComboOptions(subType, subOpts);
+                inputs[subQualifiedName] = finalizeInputValue(
+                  workflow,
+                  subQualifiedName,
+                  normalizeComboValue(subRawValue, subComboOpts)
+                );
+              } else {
+                inputs[subQualifiedName] = finalizeInputValue(
+                  workflow,
+                  subQualifiedName,
+                  normalizeWidgetValue(subRawValue, subType)
+                );
+              }
+            } else if (subHasDefault) {
+              inputs[subQualifiedName] = subOpts!.default;
+            }
+            if (subIndex !== undefined) {
+              widgetCursor = Math.max(widgetCursor, subIndex + 1);
             }
           }
         }


### PR DESCRIPTION
## Problem

ComfyUI's V3 schema declares combos as string types (`COMBO`, `COMFY_DYNAMICCOMBO_V3`, `EASY_COMBO`) with the option list in the input options object, instead of the legacy array-of-options form. The combo checks here all test `Array.isArray(typeOrOptions)`, so V3 combos aren't recognised as widgets:

- no options to pick from in the UI
- skipped when counting widget slots, which shifts every later widget index by one
- left out of the queued prompt

`COMFY_DYNAMICCOMBO_V3` additionally exposes conditional sub-inputs for the selected option, which the server expects namespaced under the parent input. Queueing a `ResizeImageMaskNode` from mobile fails with `required_input_missing: resize_type.multiplier`.

## Change

- `isComboType` / `getComboOptions` so combo detection and option lookup cover both the legacy array form and the V3 string types.
- `getDynamicComboSubInputs` resolves the sub-inputs of the selected DynamicCombo option, keeping the plain name for widget lookups and the qualified `parent.child` name for prompt submission.
- Call sites updated in `workflowInputs`, `widgetDefinitions`, `seedUtils` and `useWorkflow`, plus one line in `NodeCard` so the render check agrees with the widget-definition check (otherwise a V3 combo present in `node.inputs` without a `widget` property could render as both a widget and a connection button).

Legacy array combos are unaffected: `isComboType` is true for arrays and `getComboOptions` returns the array unchanged, so those expressions evaluate exactly as before.

## Not included

V3 handling in the 3.1.0 editing flows — add-node socket/default construction, compatible-node search, and widget-to-primitive pop-out still treat V3 combos as non-combos. Kept out to keep this reviewable; happy to follow up.

## Testing

`npm run test` (1222 pass), `npm run build`, `npm run lint` all clean. Adds unit tests for the new helpers and a fixture test driven by real `object_info` node definitions, covering each `ResizeImageMaskNode` mode plus `SaveVideo`, `SaveImageAdvanced`, `ColorTransfer`, `BasicScheduler` and an `EASY_COMBO` node.

`dist/` isn't rebuilt here — say the word if you'd rather it be in the PR than at release time.
